### PR TITLE
Fixed excess slash in makeUri

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -65,8 +65,12 @@ class Api {
     }
 
     makeUri(route) {
-        return `${this.applicationUrl}/${route}`;
+        var baseUrl = `${this.applicationUrl}`,
+            splitter = !/\/$/.test(baseUrl) && !/^\//.test(route) ? '/' : '';
+        return `${baseUrl}${splitter}${route}`;
     }
+
+
 }
 
 module.exports = Api;


### PR DESCRIPTION
When i used getIssueWorklog method defined in api-reference.json, I appeared this bug.
I will be appreciate if you agree it to master branch.